### PR TITLE
Fix DB initialization and route paths

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,11 +1,15 @@
 const express = require('express')
 const app = express()
-const path = require('path')
 const cors = require('cors')
 
 // データベース接続
-const { initDb } = require('../db')
-initDb()
+const { db, initialize } = require('../db')
+
+// 環境変数
+const PORT = process.env.PORT || 3001
+
+// データベース初期化
+initialize()
 
 // ミドルウェア
 app.use(express.json())
@@ -13,17 +17,13 @@ app.use(cors({
   origin: true,
   credentials: true
 }))
-app.use(express.json())
-
-// データベース初期化
-db.initialize()
 
 // 認証ルート
-const authRoutes = require('../routes/auth')
+const authRoutes = require('./routes/auth')
 app.use('/api/auth', authRoutes)
 
 // バスログデータルート
-const buslogRoutes = require('../routes/buslog')
+const buslogRoutes = require('./routes/buslog')
 app.use('/api/buslog', buslogRoutes)
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- correct database initialization and route imports in `api/index.js`
- load `PORT` from environment

## Testing
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684a69eb69688332b4ec5602cd7425fa