### PR TITLE
Fix route module db path

### DIFF
--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -2,7 +2,7 @@ const express = require('express')
 const router = express.Router()
 const jwt = require('jsonwebtoken')
 const bcrypt = require('bcryptjs')
-const { db } = require('../db')
+const { db } = require('../../db')
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your_jwt_secret_key'
 

--- a/api/routes/buslog.js
+++ b/api/routes/buslog.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const router = express.Router()
 const jwt = require('jsonwebtoken')
-const { db } = require('../db')
+const { db } = require('../../db')
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your_jwt_secret_key'
 


### PR DESCRIPTION
## Summary
- fix db import paths in API route modules

## Testing
- `node -e "require('./api/routes/auth'); require('./api/routes/buslog'); console.log('ok');"`
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684a6adf7c9883328ff101adc2a05fe4