### PR TITLE
Update Vercel build settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
       }
     },
     {
-      "src": "api/**/*.js",
+      "src": "api/index.js",
       "use": "@vercel/node"
     }
   ],


### PR DESCRIPTION
## Summary
- limit Node builder to `api/index.js`

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684a7dcb54f0833292dc1d27432f348d